### PR TITLE
Update esbuild in NPM to v0.21.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-plugin-pino",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "An esbuild plugin to generate extra pino files for bundling",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
The NPM hosted package still uses v0.20.x of ESBuild and after some local testing I can confirm that this works on version 0.21.x as well. Just like what is already here in the source code. So this patch version bump is just here to get NPM up-to-date with the repo.